### PR TITLE
chore: update GitHub Actions workflow to build core component

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -45,7 +45,7 @@ jobs:
           echo "Copied JSON data files to dist directory"
         
       - name: Build component
-        run: pnpm build
+        run: pnpm build:core
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
       


### PR DESCRIPTION
- Changed the build command in the GitHub Actions workflow from `pnpm build` to `pnpm build:core` to specify the core component during the build process.