### PR TITLE
chore: bump version to 1.1.3 and refactor date picker options

### DIFF
--- a/dist/types/types/index.d.ts
+++ b/dist/types/types/index.d.ts
@@ -27,32 +27,6 @@ export type DateTuple = [number, number, number];
 /**
  * Options for the Persian date picker element
  */
-export interface PersianDatePickerElementOptions {
-    /** Placeholder text for the date input */
-    placeholder?: string;
-    /** Format string for displaying the date */
-    format?: string;
-    /** Whether the date picker should use RTL layout */
-    rtl?: boolean;
-    /** Whether to enable range selection mode */
-    rangeMode?: boolean;
-    /** Start date for range selection */
-    rangeStart?: DateTuple;
-    /** End date for range selection */
-    rangeEnd?: DateTuple;
-    /** Minimum selectable date */
-    minDate?: DateTuple;
-    /** Maximum selectable date */
-    maxDate?: DateTuple;
-    /** Function or name of function to determine disabled dates */
-    disabledDates?: string | ((year: number, month: number, day: number) => boolean);
-    /** Default date to select when the component is initialized */
-    defaultDate?: DateTuple;
-    /** Whether to show events in the calendar */
-    showEvents?: boolean;
-    /** Types of events to display (e.g. 'Iran', 'Religious') */
-    eventTypes?: string[] | string;
-}
 /**
  * Event dispatched when a date is selected
  */
@@ -80,3 +54,4 @@ export interface EventsData {
     };
     events: PersianEvent[];
 }
+export * from './persian-datepicker-options';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persian-datepicker-element",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": false,
   "description": "A modern Jalali (Shamsi) Date Picker web component with shadcn-like styling",
   "main": "dist/persian-datepicker-element.min.js",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,32 +30,7 @@ export type DateTuple = [number, number, number];
 /**
  * Options for the Persian date picker element
  */
-export interface PersianDatePickerElementOptions {
-  /** Placeholder text for the date input */
-  placeholder?: string;
-  /** Format string for displaying the date */
-  format?: string;
-  /** Whether the date picker should use RTL layout */
-  rtl?: boolean;
-  /** Whether to enable range selection mode */
-  rangeMode?: boolean;
-  /** Start date for range selection */
-  rangeStart?: DateTuple;
-  /** End date for range selection */
-  rangeEnd?: DateTuple;
-  /** Minimum selectable date */
-  minDate?: DateTuple;
-  /** Maximum selectable date */
-  maxDate?: DateTuple;
-  /** Function or name of function to determine disabled dates */
-  disabledDates?: string | ((year: number, month: number, day: number) => boolean);
-  /** Default date to select when the component is initialized */
-  defaultDate?: DateTuple;
-  /** Whether to show events in the calendar */
-  showEvents?: boolean;
-  /** Types of events to display (e.g. 'Iran', 'Religious') */
-  eventTypes?: string[] | string;
-}
+
 
 /**
  * Event dispatched when a date is selected
@@ -86,3 +61,5 @@ export interface EventsData {
   };
   events: PersianEvent[];
 } 
+
+export * from './persian-datepicker-options'

--- a/src/types/persian-datepicker-options.ts
+++ b/src/types/persian-datepicker-options.ts
@@ -1,22 +1,31 @@
+import { DateTuple } from "./date-tuple";
+
 /**
  * Configuration options for the Persian Date Picker Element
  */
 export interface PersianDatePickerElementOptions {
-  /** Color for selected dates and highlights */
-  primaryColor?: string;
-  
-  /** Text direction (true for RTL, false for LTR) */
-  rtl?: boolean;
-  
-  /** Placeholder text for the input field */
+  /** Placeholder text for the date input */
   placeholder?: string;
-  
-  /** Date format pattern (YYYY = year, MM = month, DD = day) */
+  /** Format string for displaying the date */
   format?: string;
-  
-  /** Custom CSS variables to override default styling */
-  cssVariables?: Record<string, string>;
-  
-  /** Types of holidays to display (e.g. 'Iran', 'Religious') */
+  /** Whether the date picker should use RTL layout */
+  rtl?: boolean;
+  /** Whether to enable range selection mode */
+  rangeMode?: boolean;
+  /** Start date for range selection */
+  rangeStart?: DateTuple;
+  /** End date for range selection */
+  rangeEnd?: DateTuple;
+  /** Minimum selectable date */
+  minDate?: DateTuple;
+  /** Maximum selectable date */
+  maxDate?: DateTuple;
+  /** Function or name of function to determine disabled dates */
+  disabledDates?: string | ((year: number, month: number, day: number) => boolean);
+  /** Default date to select when the component is initialized */
+  defaultDate?: DateTuple;
+  /** Whether to show events in the calendar */
+  showEvents?: boolean;
+  /** Types of events to display (e.g. 'Iran', 'Religious') */
   eventTypes?: string[] | string;
-} 
+}


### PR DESCRIPTION
- Updated version in package.json to 1.1.3.
- Refactored PersianDatePickerElementOptions by moving options to a dedicated file for better organization and maintainability.
- Removed redundant options from the main type definition to streamline the codebase.