### PR TITLE
chore: bump version to 1.1.7 and update dependencies

### DIFF
--- a/packages/angular/ngx-persian-datepicker-element/package.json
+++ b/packages/angular/ngx-persian-datepicker-element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-persian-datepicker-element",
-  "version": "1.1.2",
+  "version": "1.1.7",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -16,7 +16,7 @@
     "@angular/platform-browser": "^19.2.0",
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/router": "^19.2.0",
-    "persian-datepicker-element": "^1.0.11",
+    "persian-datepicker-element": "^1.1.7",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/packages/angular/ngx-persian-datepicker-element/projects/ngx-persian-datepicker-element/package.json
+++ b/packages/angular/ngx-persian-datepicker-element/projects/ngx-persian-datepicker-element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-persian-datepicker-element",
-  "version": "1.1.2",
+  "version": "1.1.7",
   "description": "Angular wrapper for Persian DatePicker Web Component with signal-based inputs (English/Persian docs)",
   "author": "Ahmad",
   "license": "MIT",
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "tslib": "^2.3.0",
-    "persian-datepicker-element": "^1.0.29"
+    "persian-datepicker-element": "^1.1.7"
   },
   "peerDependencies": {
     "@angular/common": "^16.0.0 || ^17.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-persian-datepicker-element",
-  "version": "1.1.3",
+  "version": "1.1.7",
   "description": "React wrapper for Persian Datepicker Web Component - A beautiful and fully customizable Jalali date picker",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -41,7 +41,7 @@
   "author": "Ahmad Mehrabi",
   "license": "MIT",
   "dependencies": {
-    "persian-datepicker-element": "^1.0.29"
+    "persian-datepicker-element": "^1.1.7"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-persian-datepicker-element",
-  "version": "1.1.2",
+  "version": "1.1.7",
   "description": "Vue wrapper for persian-datepicker-element",
   "main": "dist/index.umd.js",
   "module": "dist/index.es.js",
@@ -41,7 +41,7 @@
   "author": "Ahmad Mehrabi",
   "license": "MIT",
   "dependencies": {
-    "persian-datepicker-element": "^1.0.29",
+    "persian-datepicker-element": "^1.1.7",
     "vue": "^3.4.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
- Updated version in package.json to 1.1.7 for Angular, React, and Vue packages.
- Updated dependency "persian-datepicker-element" to version 1.1.7 across all packages.