### PR TITLE
feat: explicitly set disabled dates function for combined date picker

### DIFF
--- a/demo/examples/limits.html
+++ b/demo/examples/limits.html
@@ -556,6 +556,9 @@ methodPicker.setAttribute('disabled-dates', 'isWorkingDay');</code></pre>
     const combinedPicker = document.getElementById('combined-picker');
     const combinedResult = document.getElementById('combined-result');
     
+    // Explicitly set the disabledDatesFn to ensure it works correctly with min/max date
+    combinedPicker.setDisabledDatesFn(isWeekend);
+    
     combinedPicker.addEventListener('change', (event) => {
       console.log(event);
       combinedResult.textContent = formatPersianDate(event.detail.jalali);


### PR DESCRIPTION
- Added a line to set the disabledDatesFn for the combined date picker to ensure it correctly disables weekends.
- This enhancement improves the functionality of the date picker by preventing selection of non-working days.