### PR TITLE
chore: update installation instructions in README for React and Vue

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -18,9 +18,11 @@ A modern, fully-featured Persian (Jalali) date picker component for React applic
 ## Installation
 
 ```bash
-npm install persian-datepicker-react
+npm install react-persian-datepicker-element persian-datepicker-element
 # or
-yarn add persian-datepicker-react
+yarn add react-persian-datepicker-element persian-datepicker-element
+# or
+pnpm add react-persian-datepicker-element persian-datepicker-element
 ```
 
 ## Basic Usage
@@ -143,9 +145,11 @@ datepickerRef.current.clear();
 ## نصب
 
 ```bash
-npm install persian-datepicker-react
+npm install react-persian-datepicker-element persian-datepicker-element
 # یا
-yarn add persian-datepicker-react
+yarn add react-persian-datepicker-element persian-datepicker-element
+# یا
+pnpm add react-persian-datepicker-element persian-datepicker-element
 ```
 
 ## استفاده پایه

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -17,9 +17,11 @@ A modern, fully-featured Persian (Jalali) date picker component for Vue 3 applic
 ## Installation
 
 ```bash
-npm install persian-datepicker-vue
+npm install vue-persian-datepicker-element persian-datepicker-element
 # or
-yarn add persian-datepicker-vue
+yarn add vue-persian-datepicker-element persian-datepicker-element
+# or
+pnpm add vue-persian-datepicker-element persian-datepicker-element
 ```
 
 ## Basic Usage
@@ -158,9 +160,11 @@ const handleRangeChange = (event) => {
 ## نصب
 
 ```bash
-npm install persian-datepicker-vue
+npm install vue-persian-datepicker-element persian-datepicker-element
 # یا
-yarn add persian-datepicker-vue
+yarn add vue-persian-datepicker-element persian-datepicker-element
+# یا
+pnpm add vue-persian-datepicker-element persian-datepicker-element
 ```
 
 ## استفاده پایه


### PR DESCRIPTION
- Changed package names in installation instructions to reflect the new structure: `react-persian-datepicker-element` and `vue-persian-datepicker-element`.
- Added support for `pnpm` as an installation option in both React and Vue README files.