### PR TITLE
chore: update import paths for Persian Datepicker in Angular examples

### DIFF
--- a/demo/examples/docs/frameworks/angular.html
+++ b/demo/examples/docs/frameworks/angular.html
@@ -403,7 +403,7 @@ pnpm add ngx-persian-datepicker-element persian-datepicker-element</code></pre>
       <pre><code>// app.module.ts
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { PersianDatepickerModule } from 'angular-persian-datepicker-element';
+import { PersianDatepickerModule } from 'ngx-persian-datepicker-element';
 
 import { AppComponent } from './app.component';
 
@@ -431,7 +431,7 @@ export class AppModule { }</code></pre>
 
       <pre><code>// app.component.ts
 import { Component } from '@angular/core';
-import { PersianDateChangeEvent } from 'angular-persian-datepicker-element';
+import { PersianDateChangeEvent } from 'ngx-persian-datepicker-element';
 
 @Component({
   selector: 'app-root',
@@ -538,7 +538,7 @@ export class AppComponent {
 
           <pre><code>// app.component.ts
 import { Component, ViewChild } from '@angular/core';
-import { PersianDatepickerComponent } from 'angular-persian-datepicker-element';
+import { PersianDatepickerComponent } from 'ngx-persian-datepicker-element';
 
 @Component({
   selector: 'app-root',
@@ -790,7 +790,7 @@ import {
   PersianDatepickerComponent,
   PersianDateChangeEvent,
   DateTuple 
-} from 'angular-persian-datepicker-element';
+} from 'ngx-persian-datepicker-element';
 
 @Component({
   selector: 'app-root',


### PR DESCRIPTION
- Changed import statements in Angular example files to use 'ngx-persian-datepicker-element' instead of 'angular-persian-datepicker-element'.
- Ensured consistency across app.module.ts and app.component.ts files for the updated package name.