### PR TITLE
fix: correct date initialization format in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ export class AppComponent {
 
   constructor(private fb: FormBuilder) {
     this.dateForm = this.fb.group({
-      date: [[1403, 6, 15]] // Initial value: [year, month, day]
+      date: [1403, 6, 15] // Initial value: [year, month, day]
     });
   }
 }

--- a/packages/angular/ngx-persian-datepicker-element/README.md
+++ b/packages/angular/ngx-persian-datepicker-element/README.md
@@ -106,7 +106,7 @@ export class MyFormComponent implements OnInit {
 
   ngOnInit() {
     this.myForm = this.fb.group({
-      date: [[1403, 6, 15]] // Initial value: [year, month, day]
+      date: [1403, 6, 15] // Initial value: [year, month, day]
     });
 
     // Subscribe to value changes


### PR DESCRIPTION
- Updated the date initialization in both the main README and the ngx-persian-datepicker-element README to use a single array instead of a nested array for the date value.
- Ensured consistency in the date format across documentation examples for clarity.